### PR TITLE
builder: Add git

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,4 +19,4 @@ pkginstall buildah
 pkginstall cargo openssl-devel
 
 # Build tools
-pkginstall selinux-policy-targeted osbuild crypto-policies-scripts sudo
+pkginstall git-core selinux-policy-targeted osbuild crypto-policies-scripts sudo


### PR DESCRIPTION
For general utility, but specifically needed to gather `SOURCE_DATE_EPOCH` from the git commit in downstream builds.